### PR TITLE
Remove handlers caching from PaysafeApiClient since they are instanti…

### DIFF
--- a/lib/PaysafeApiClient.js
+++ b/lib/PaysafeApiClient.js
@@ -116,34 +116,20 @@ var prepareRequestParameter = function(requestObject) {
 	}
 };
 
-var cardService;
 PaysafeApiClient.prototype.cardServiceHandler = function(paysafeApiClient) {
-	if (!cardService) {
-		cardService = new cardServiceHandler(paysafeApiClient);
-	}
-	return cardService;
-};
-var customerService;
-PaysafeApiClient.prototype.CustomerServiceHandler = function(paysafeApiClient) {
-	if (!customerService) {
-		customerService = new CustomerServiceHandler(paysafeApiClient);
-	}
-	return customerService;
+	return new cardServiceHandler(paysafeApiClient);
 };
 
-var directDebitService;
-PaysafeApiClient.prototype.DirectDebitServiceHandler = function(paysafeApiClient) {
-	if (!directDebitService) {
-		directDebitService = new DirectDebitServiceHandler(paysafeApiClient);
-	}
-	return directDebitService;
+PaysafeApiClient.prototype.CustomerServiceHandler = function(paysafeApiClient) {
+	return new CustomerServiceHandler(paysafeApiClient);
 };
-var threeDsecureService;
+
+PaysafeApiClient.prototype.DirectDebitServiceHandler = function(paysafeApiClient) {
+	return new DirectDebitServiceHandler(paysafeApiClient);
+};
+
 PaysafeApiClient.prototype.ThreeDsecureServiceHandler = function(paysafeApiClient) {
-	if (!threeDsecureService) {
-		threeDsecureService = new ThreeDsecureServiceHandler(paysafeApiClient);
-	}
-	return threeDsecureService;
+	return new ThreeDsecureServiceHandler(paysafeApiClient);
 };
 
 PaysafeApiClient.prototype.processRequest = function(PaysafeRequest,


### PR DESCRIPTION
Remove handlers caching from PaysafeApiClient since they are instantiated with request-critical information (such as the accountNumber contained in the ApiClient). Fixes an issue where making two requests in a single process lifetime would pin the first account number used to the process.